### PR TITLE
SEC-090: Automated trusted workflow pinning (2023-03-10)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Run Instruqt Validate
         env:
           INSTRUQT_TOKEN : ${{ secrets.INSTRUQT_TOKEN }}
@@ -55,7 +55,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Terraform Build Your Own Provider Workshop
         env:
           INSTRUQT_TOKEN : ${{ secrets.INSTRUQT_TOKEN }}


### PR DESCRIPTION
This PR pins action references in workflow and action files to SHAs.
This is in support of [SEC-090](https://github.com/hashicorp/security-tsccr/issues/214);
Any questions please reach out to [#team-prodsec](https://go.hashi.co/team-prodsec)
